### PR TITLE
Refresh UI docs and fix README copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _**[Jian Lin](https://github.com/dmMaze)<sup>1</sup>, [Chengze Li](https://moeka
 
 <sup>*</sup>Corresponding author
 
-Conditionally accpted to appear in *ACM SIGGRAPH 2026 Conference Proceedings*.
+Conditionally accepted to appear in *ACM SIGGRAPH 2026 Conference Proceedings*.
 
 </div>
 
@@ -203,14 +203,14 @@ If you build tools, extensions, or workflows on top of this project, please let 
 
 - [ComfyUI-See-through](https://github.com/jtydhr88/ComfyUI-See-through) by [@jtydhr88](https://github.com/jtydhr88) — Integration for ComfyUI, with node-based workflow and in-browser PSD export. Thank you for the amazing work!
 
-We also seek for i18n help for this project. Your help will be highly appreciated. 
+We also seek i18n help for this project. Your help will be highly appreciated.
 
 
 ## Discussion: Is this Image-to-Live2D?
 
 We don't think so — at least, not yet.
 
-While we produces 2.5D layer decompositions from a single image,
+While we produce 2.5D layer decompositions from a single image,
 the full Image-to-Live2D pipeline requires significantly more:
 
 1. **Finer artistic decomposition.** Live2D models demand layers designed with specific


### PR DESCRIPTION
## Summary

This PR updates stale UI installation docs and fixes a few small README copy issues.

## What changed

- Replaced the outdated setup instructions in `ui/ui/readme.md`
- Aligned the inner UI README with the root `README.md` and `ui/README.md`
- Switched the UI setup flow to the unified `see_through` conda environment
- Updated the install steps to use:
  - Python 3.12
  - the root `requirements.txt`
  - the optional `requirements-inference-mmdet.txt` tier
- Added a macOS note clarifying:
  - CUDA is not available on macOS
  - the main inference pipeline still hardcodes CUDA
  - `mmcv` may require a source build for CPU-only or MPS setups
- Kept the existing `Usage` and `Tips & Shortcuts` sections unchanged except for one small grammar fix
- Fixed a few minor copy edits in the root `README.md`

## Why

`ui/ui/readme.md` was still describing an older installation path based on Python 3.10/3.11, PyTorch 2.1.0, and manual `openmim` / `mmcv` / `mmdet` installation. That no longer matched the current repo setup documented in the root README and requirements files.

## Prompt that would produce similar fixes

```text
Update ui/ui/readme.md so its installation instructions match the root README and current requirements files. Replace any stale Python, PyTorch, mmcv, or mmdet setup steps with the repo’s unified conda environment flow. Keep usage and shortcuts unchanged.

Compare README.md, ui/README.md, ui/ui/readme.md, requirements.txt, and requirements-inference-mmdet.txt. Fix any setup instructions in the inner UI README that contradict the current root-level install process, and add a cautious macOS note about CUDA and mmcv support.

Do a docs-only cleanup pass: refresh outdated installation instructions, preserve accurate usage sections, and fix minor grammar/spelling issues in the main README without changing code.
```