### PR TITLE
Add AMD ROCm install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ pip install torch==2.8.0+cu128 torchvision==0.23.0+cu128 torchaudio==2.8.0+cu128
   --index-url https://download.pytorch.org/whl/cu128
 
 # AMD ROCm users: install the ROCm wheel set that matches your local ROCm runtime instead.
-# For example, on ROCm 7.2:
+# For example, on ROCm 7.2.1:
 # pip install torch torchvision torchaudio \
-#   --index-url https://download.pytorch.org/whl/rocm7.2
+#   --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.1
 
 # 3. Install dependencies (includes common utilities and annotators)
 pip install -r requirements.txt
@@ -63,11 +63,6 @@ pip install -r requirements.txt
 # 4. Create assets symlink (you can also copy assets to the root if you prefer)
 ln -sf common/assets assets
 ```
-
-For ROCm multi-GPU systems, select one GPU with `HIP_VISIBLE_DEVICES`; after
-masking, keep `CUDA_VISIBLE_DEVICES=0` so PyTorch sees the selected device as
-device 0. `HSA_ENABLE_SDMA=0` can help avoid initialization or small-kernel hangs
-on some newer Radeon systems.
 
 **Optional annotator tiers** (install as needed):
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ pip install torch==2.8.0+cu128 torchvision==0.23.0+cu128 torchaudio==2.8.0+cu128
   --index-url https://download.pytorch.org/whl/cu128
 
 # AMD ROCm users: install the ROCm wheel set that matches your local ROCm runtime instead.
-# For example, on ROCm 7.2.1:
+# For example, on ROCm 7.2:
 # pip install torch torchvision torchaudio \
-#   --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.1
+#   --index-url https://download.pytorch.org/whl/rocm7.2
 
 # 3. Install dependencies (includes common utilities and annotators)
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -52,12 +52,22 @@ conda activate see_through
 pip install torch==2.8.0+cu128 torchvision==0.23.0+cu128 torchaudio==2.8.0+cu128 \
   --index-url https://download.pytorch.org/whl/cu128
 
+# AMD ROCm users: install the ROCm wheel set that matches your local ROCm runtime instead.
+# For example, on ROCm 7.2:
+# pip install torch torchvision torchaudio \
+#   --index-url https://download.pytorch.org/whl/rocm7.2
+
 # 3. Install dependencies (includes common utilities and annotators)
 pip install -r requirements.txt
 
 # 4. Create assets symlink (you can also copy assets to the root if you prefer)
 ln -sf common/assets assets
 ```
+
+For ROCm multi-GPU systems, select one GPU with `HIP_VISIBLE_DEVICES`; after
+masking, keep `CUDA_VISIBLE_DEVICES=0` so PyTorch sees the selected device as
+device 0. `HSA_ENABLE_SDMA=0` can help avoid initialization or small-kernel hangs
+on some newer Radeon systems.
 
 **Optional annotator tiers** (install as needed):
 


### PR DESCRIPTION
## Summary
related issues: https://github.com/shitagaki-lab/see-through/issues/27 https://github.com/shitagaki-lab/see-through/issues/26
- Add AMD ROCm wheel installation notes to the Environment Setup section.
- Update the ROCm example to use the Radeon ROCm 7.2.1 manylinux wheel index.
- Keep the change documentation-only and scoped to the PyTorch installation step.

## Tested

- Created a fresh conda environment with Python 3.12.
- Installed PyTorch ROCm wheels from `https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.1`.
- Ran `inference/scripts/inference_psd.py` on AMD Radeon AI PRO R9700 with ROCm 7.2 / PyTorch `2.9.1+rocm7.2.1`.
- Successfully generated both layered PSD and depth PSD outputs.
<img width="1016" height="896" alt="image" src="https://github.com/user-attachments/assets/37f37491-5387-4fa4-9a0a-f2b585d86aa4" />
