### PR TITLE
fix: full Apple Silicon (MPS) support and resolve 5D tensor median crash

### DIFF
--- a/common/modules/layerdiffuse/vae.py
+++ b/common/modules/layerdiffuse/vae.py
@@ -229,7 +229,7 @@ class TransparentVAEDecoder(torch.nn.Module):
             break
 
         result = torch.stack(result, dim=0)
-        median = torch.median(result, dim=0).values
+        median = torch.median(result.cpu(), dim=0).values.to(result.device)
         return median
 
     @torch.no_grad()

--- a/common/modules/marigold/util/ensemble.py
+++ b/common/modules/marigold/util/ensemble.py
@@ -126,11 +126,11 @@ def ensemble_depth(
             if return_uncertainty:
                 uncertainty = torch.std(depth_aligned, dim=0, keepdim=True)
         elif reduction == "median":
-            prediction = torch.median(depth_aligned, dim=0, keepdim=True).values
+            prediction = torch.median(depth_aligned.cpu(), dim=0, keepdim=True).values.to(depth_aligned.device)
             if return_uncertainty:
                 uncertainty = torch.median(
-                    torch.abs(depth_aligned - prediction), dim=0, keepdim=True
-                ).values
+                    torch.abs(depth_aligned.cpu() - prediction.cpu()), dim=0, keepdim=True
+                ).values.to(depth_aligned.device)
         else:
             raise ValueError(f"Unrecognized reduction method: {reduction}.")
         return prediction, uncertainty
@@ -260,11 +260,11 @@ def ensemble_iid(
         if output_uncertainty:
             uncertainty = torch.std(targets, dim=0, keepdim=True)
     elif reduction == "median":
-        prediction = torch.median(targets, dim=0, keepdim=True).values
+        prediction = torch.median(targets.cpu(), dim=0, keepdim=True).values.to(targets.device)
         if output_uncertainty:
             uncertainty = torch.median(
-                torch.abs(targets - prediction), dim=0, keepdim=True
-            ).values
+                torch.abs(targets.cpu() - prediction.cpu()), dim=0, keepdim=True
+            ).values.to(targets.device)
     else:
         raise ValueError(f"Unrecognized reduction method: {reduction}.")
     return prediction, uncertainty

--- a/common/utils/inference_utils.py
+++ b/common/utils/inference_utils.py
@@ -62,13 +62,14 @@ def apply_layerdiff(
                 layerdiff_pipeline.trans_vae.decoder.load_state_dict(td_sd)
                 print(f'load vae from {vae_ckpt}')
 
-        layerdiff_pipeline.vae.to(dtype=torch.bfloat16, device='cuda')
-        layerdiff_pipeline.trans_vae.to(dtype=torch.bfloat16, device='cuda')
-        layerdiff_pipeline.unet.to(dtype=torch.bfloat16, device='cuda')
-        layerdiff_pipeline.text_encoder.to(dtype=torch.bfloat16, device='cuda')
-        layerdiff_pipeline.text_encoder_2.to(dtype=torch.bfloat16, device='cuda')
+        device = 'cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu'
+        layerdiff_pipeline.vae.to(dtype=torch.bfloat16, device=device)
+        layerdiff_pipeline.trans_vae.to(dtype=torch.bfloat16, device=device)
+        layerdiff_pipeline.unet.to(dtype=torch.bfloat16, device=device)
+        layerdiff_pipeline.text_encoder.to(dtype=torch.bfloat16, device=device)
+        layerdiff_pipeline.text_encoder_2.to(dtype=torch.bfloat16, device=device)
         if group_offload:
-            layerdiff_pipeline.enable_group_offload('cuda', num_blocks_per_group=1)
+            layerdiff_pipeline.enable_group_offload(device, num_blocks_per_group=1)
 
     pipeline = layerdiff_pipeline
     if cache_tag_embeds:
@@ -192,10 +193,11 @@ def apply_marigold(srcp, pretrained: str, num_inference_steps=-1, seed=0, save_d
     if marigold_pipeline is None:
         unet = UNetFrameConditionModel.from_pretrained(pretrained, subfolder='unet')
         marigold_pipeline = MarigoldDepthPipeline.from_pretrained(pretrained, unet=unet)
-        marigold_pipeline.to(device='cuda', dtype=torch.bfloat16)
+        device = 'cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu'
+        marigold_pipeline.to(device=device, dtype=torch.bfloat16)
 
         if group_offload:
-            marigold_pipeline.enable_group_offload('cuda', num_blocks_per_group=1)
+            marigold_pipeline.enable_group_offload(device, num_blocks_per_group=1)
 
     pipe = marigold_pipeline
 


### PR DESCRIPTION
### Summary of Changes

This PR provides full Apple Silicon (MPS) backend support, extending previous attempts by addressing a critical runtime crash during VAE decoding and depth ensembling:

1. **Dynamic Device Selection & Offload**: Replaced hardcoded `device='cuda'` in `common/utils/inference_utils.py` with dynamic device detection (`cuda` / `mps` / `cpu`).
2. **Fix MPS 5D Tensor Median Crash (Critical)**: Fixed PyTorch MPS backend assertion failure (`MPSNDArraySort.mm:252: failed assertion Axis = 4`) during VAE decoding (`common/modules/layerdiffuse/vae.py`) and Marigold depth ensemble (`common/modules/marigold/util/ensemble.py`) by calculating `torch.median` on CPU and transferring the reduced tensor back to target device.

### Verification
- Tested on macOS (Apple Silicon M4 Pro) with PyTorch MPS backend.
- Confirmed end-to-end execution: successfully performed 23-layer image decomposition and generated valid PSD files without crashes.