### PR TITLE
Migrate torch.cuda.amp.autocast to torch.amp (annotator + loss_depth.py)

### DIFF
--- a/annotators/animeinsseg/rtmdet_inshead_custom.py
+++ b/annotators/animeinsseg/rtmdet_inshead_custom.py
@@ -153,7 +153,7 @@ class RTMDetInsHeadCustom(RTMDetInsHead):
         n_layers = len(weights)
         x = mask_feat.reshape(1, -1, h, w)
         for i, (weight, bias) in enumerate(zip(weights, biases)):
-            with torch.cuda.amp.autocast(enabled=False):
+            with torch.amp.autocast("cuda", enabled=False):
                 if fp16_used:
                     weight = weight.to(torch.float32)
                     bias = bias.to(torch.float32)
@@ -272,7 +272,7 @@ class RTMDetInsSepBNHeadCustom(RTMDetInsSepBNHead):
         n_layers = len(weights)
         x = mask_feat.reshape(1, -1, h, w)
         for i, (weight, bias) in enumerate(zip(weights, biases)):
-            with torch.cuda.amp.autocast(enabled=False):
+            with torch.amp.autocast("cuda", enabled=False):
                 if fp16_used:
                     weight = weight.to(torch.float32)
                     bias = bias.to(torch.float32)

--- a/annotators/animeinsseg/skytnt_segmentation.py
+++ b/annotators/animeinsseg/skytnt_segmentation.py
@@ -27,7 +27,7 @@ def apply_segmentation(input_img, use_amp=True, s=640, model=None):
     tmpImg = torch.from_numpy(tmpImg).unsqueeze(0).type(torch.FloatTensor).to(model.device)
     with torch.no_grad():
         if use_amp:
-            with torch.cuda.amp.autocast():
+            with torch.amp.autocast("cuda"):
                 pred = model(tmpImg)
         else:
             pred = model(tmpImg)

--- a/training/train/loss_depth.py
+++ b/training/train/loss_depth.py
@@ -25,7 +25,10 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torch.cuda.amp as amp
+# torch.cuda.amp is deprecated since torch 2.4; the import below targets
+# torch.amp (same API, no warning). Kept only for the commented-out block
+# below; if that block is removed, this import should go with it.
+import torch.amp as amp
 import numpy as np
 
 
@@ -163,7 +166,7 @@ def compute_metrics(gt, pred, interpolate=True, mask=None, garg_crop=False, eige
 #             input = input[mask]
 #             target = target[mask]
 
-#         with amp.autocast(enabled=False):  # amp causes NaNs in this loss function
+#         with amp.autocast("cuda", enabled=False):  # amp causes NaNs in this loss function
 #             alpha = 1e-7
 #             g = torch.log(input + alpha) - torch.log(target + alpha)
 


### PR DESCRIPTION
Fixes #36

### Summary

`torch.cuda.amp.autocast` has been deprecated since torch 2.4 and is scheduled for removal. This PR migrates all three real call sites in the annotator path and cleans up the training-code import:

- [annotators/animeinsseg/skytnt_segmentation.py:30](https://github.com/shitagaki-lab/see-through/blob/main/annotators/animeinsseg/skytnt_segmentation.py#L30) — inference path (reached via `inference/scripts/parse_live2d.py` and the UI thread):
  ```diff
  -            with torch.cuda.amp.autocast():
  +            with torch.amp.autocast("cuda"):
  ```
- [annotators/animeinsseg/rtmdet_inshead_custom.py:156, 275](https://github.com/shitagaki-lab/see-through/blob/main/annotators/animeinsseg/rtmdet_inshead_custom.py#L156) — `enabled=False` semantics preserved:
  ```diff
  -            with torch.cuda.amp.autocast(enabled=False):
  +            with torch.amp.autocast("cuda", enabled=False):
  ```
- [training/train/loss_depth.py:28](https://github.com/shitagaki-lab/see-through/blob/main/training/train/loss_depth.py#L28) — the import only serves the commented-out block at line 166; it is **kept** (removal is left to the maintainers, together with that block), but retargeted to `torch.amp` with an explanatory comment, and the commented call is updated to the new API:
  ```diff
  -import torch.cuda.amp as amp
  +# torch.cuda.amp is deprecated since torch 2.4; the import below targets
  +# torch.amp (same API, no warning). Kept only for the commented-out block
  +# below; if that block is removed, this import should go with it.
  +import torch.amp as amp
  ...
  -#         with amp.autocast(enabled=False):  # amp causes NaNs in this loss function
  +#         with amp.autocast("cuda", enabled=False):  # amp causes NaNs in this loss function
  ```

`torch.amp.autocast("cuda", ...)` is available since torch 2.0, well below the pinned `torch==2.8.0+cu128` floor, and has the same semantics.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Validation

Verified on torch 2.11.0 with `warnings.simplefilter("error", FutureWarning)`:

- `torch.amp.autocast("cuda", enabled=False)` and the `import torch.amp as amp` + `amp.autocast("cuda", enabled=False)` forms run warning-free.
- Control group: `torch.cuda.amp.autocast(enabled=False)` raises `FutureWarning` under the same filter — the fix is effective and the filter is sensitive.
- `py_compile` passes on all three touched files; the repo now has zero code references to `torch.cuda.amp` (grep-verified).

### User impact

No behavior change; the `FutureWarning` emitted by every annotator run and by AMP-enabled training on torch 2.4+ is eliminated, as is the breakage risk once `torch.cuda.amp` is removed.

### Notes for reviewers

- The `enabled=False` contexts are intentionally preserved — they disable autocast regardless of the ambient setting (matching the original semantics).
- Same migration as [ultralytics/yolov5#13244](https://github.com/ultralytics/yolov5/pull/13244) and [huggingface/lerobot#3167](https://github.com/huggingface/lerobot/pull/3167).